### PR TITLE
update search and fix inline code warning

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -62,7 +62,12 @@ module.exports = {
               wrapperStyle: `margin-bottom: 1.0725rem`,
             },
           },
-          `gatsby-remark-prismjs`,
+          {
+            resolve: `gatsby-remark-prismjs`,
+            options: {
+              inlineCodeMarker: `±`,
+            },
+          },
           `gatsby-remark-copy-linked-files`,
         ],
       },
@@ -169,7 +174,6 @@ module.exports = {
       options: {
         appId: process.env.GATSBY_ALGOLIA_APP_ID,
         apiKey: process.env.ALGOLIA_ADMIN_KEY,
-        // indexName: process.env.ALGOLIA_INDEX_NAME, // for all queries
         queries,
         chunkSize: 20000, // default: 1000
       },

--- a/src/components/search/Hits.js
+++ b/src/components/search/Hits.js
@@ -1,28 +1,8 @@
 import { Link } from 'gatsby'
-import React from 'react' //, { Fragment }
+import React from 'react'
 import { connectHits, Highlight, Snippet } from 'react-instantsearch-dom'
-import { CalendarIcon } from './styles'
-// import { Tags } from 'styled-icons/fa-solid/Tags'
 
-const postHit = hit => (
-  <div>
-    <CalendarIcon size="1em" />
-    &nbsp;
-    <Highlight attribute="date" hit={hit} tagName="mark" />
-    {/* &emsp;
-    <Tags size="1em" />
-    &nbsp;
-    {hit.tags.map((tag, index) => (
-      <Fragment key={tag}>
-        {index > 0 && `, `}
-        {tag}
-      </Fragment>
-    ))} */}
-  </div>
-)
-
-export default connectHits(function HitComp({ type, hits, onClick }) {
-  const extend = { postHit }[type]
+export default connectHits(function HitComp({ hits, onClick }) {
   return hits.map(hit => (
     <div key={hit.objectID}>
       <Link to={hit.slug} onClick={onClick}>
@@ -30,7 +10,6 @@ export default connectHits(function HitComp({ type, hits, onClick }) {
           <Highlight attribute="title" hit={hit} tagName="mark" />
         </h4>
       </Link>
-      {extend && extend(hit)}
       <Snippet attribute="excerpt" hit={hit} tagName="mark" />
     </div>
   ))

--- a/src/components/search/styles.js
+++ b/src/components/search/styles.js
@@ -2,7 +2,6 @@ import React from 'react'
 import styled, { css } from 'styled-components'
 import { Algolia } from 'styled-icons/fa-brands/Algolia'
 import { Search } from 'styled-icons/fa-solid/Search'
-import { Calendar } from 'styled-icons/octicons/Calendar'
 
 const amethystSmoke = `hsl(252,16%,64%)`
 const amethystSmokeDiaphanous = `hsl(252,16%,64%,0.7)`
@@ -30,12 +29,6 @@ export const Root = styled.div`
 export const SearchIcon = styled(Search)`
   width: 1em;
   pointer-events: none;
-`
-
-export const CalendarIcon = styled(Calendar)`
-  width: 1em;
-  pointer-events: none;
-  vertical-align: -0.1875em;
 `
 
 export const Form = styled.form`

--- a/src/css/prism/prism-day-after-tomorrow.css
+++ b/src/css/prism/prism-day-after-tomorrow.css
@@ -1,7 +1,7 @@
 /**
  * prism.js tomorrow night eighties for JavaScript, CoffeeScript, CSS and HTML
  * Based on https://github.com/chriskempson/tomorrow-theme
- * @author Rose Pritchard
+ * @author Rose Pritchard and Ricky de Laveaga
  */
 
 code[class*="language-"],
@@ -42,8 +42,8 @@ pre[class*="language-"] {
 
 /* Inline code */
 :not(pre) > code[class*="language-"] {
-	padding: .125em;
-	border-radius: .3em;
+	padding: 0.125em 0 0.15625em;
+	border-radius: 0.3em;
 	white-space: normal;
 }
 

--- a/src/pages/credits/index.md
+++ b/src/pages/credits/index.md
@@ -56,7 +56,7 @@ including NPM packages for open source typefaces and self-hosting webfonts
 significantly easier. Library author Kyle Mathews explained the motivations
 [in&nbsp;January&nbsp;2017](https://www.bricolage.io/typefaces-easiest-way-to-self-host-fonts/).
 
-Though the `git clone` example above hardly does it justice,
+Though the `shell±git clone` example above hardly does it justice,
 gatsby-remark-prismjs ([docs](https://www.gatsbyjs.org/packages/gatsby-remark-prismjs/), [on&nbsp;GitHub](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs))
 makes adding “syntax highlighting to code blocks in markdown files” using
 [Prism](https://github.com/PrismJS/prism) a drop-in affair with a line in
@@ -86,7 +86,7 @@ especially helpful to me in putting this&nbsp;together.
 **UPDATE 20 November 2019:** I have been using Algolia search since 24 July 2019
 via [gatsby-plugin-algolia](https://github.com/algolia/gatsby-plugin-algolia),
 thanks to the
-[excellent example by Janosh](https://janosh.io/blog/gatsby-algolia-search)
+[excellent example by Janosh Riebesell](https://janosh.io/blog/gatsby-algolia-search)
 that has become
 [part of the Gatsby docs](https://www.gatsbyjs.org/docs/adding-search-with-algolia/). I don’t think either article has been updated for changes [React InstantSearch](https://github.com/algolia/react-instantsearch) made in
 [v6](https://github.com/algolia/react-instantsearch/blob/master/MIGRATION.md#upgrade-to-6xx)
@@ -104,13 +104,13 @@ As an instant bonus for reading all the way down, I give you&nbsp;the…
 
 <br />
 
-[^gatsby-new]: Having already installed `gatsby-cli`, One could run: <br />
- `gatsby new mySite https://github.com/gatsbyjs/gatsby-starter-blog`<br />
- …in the terminal instead of a `git clone` of the
+[^gatsby-new]: Having already installed `shell±gatsby-cli`, One could run: <br />
+ `shell±gatsby new mySite https://github.com/gatsbyjs/gatsby-starter-blog`<br />
+ …in the terminal instead of a `shell±git clone` of the
  [gatsby-starter-blog repo](https://github.com/gatsbyjs/gatsby-starter-blog)
- like I did, which then needs to be followed by a `yarn` or `npm i` before
- running `gatsby develop` for the first time. The
- [Gatsby&nbsp;Docs](https://www.gatsbyjs.org/docs/) start with the `gatsby new`
- command which takes care of this initial package install. (For more on `git`
+ like I did, which then needs to be followed by a `shell±yarn` or `shell±npm i` before
+ running `shell±gatsby develop` for the first time. The
+ [Gatsby&nbsp;Docs](https://www.gatsbyjs.org/docs/) start with the `shell±gatsby new`
+ command which takes care of this initial package install. (For more on `shell±git`
  and cloning, see [git-clone docs](https://www.git-scm.com/docs/git-clone).)
- The source of the `gatsby new` command is split between [create-cli.js](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-cli/src/create-cli.js) and [init-starter.js](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-cli/src/init-starter.js) in the Gatsby&nbsp;repo.
+ The source of the `shell±gatsby new` command is split between [create-cli.js](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-cli/src/create-cli.js) and [init-starter.js](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-cli/src/init-starter.js) in the Gatsby&nbsp;repo.

--- a/src/utils/algolia.js
+++ b/src/utils/algolia.js
@@ -14,11 +14,6 @@ const postQuery = `{
         frontmatter {
           title
           frontmatterExcerpt: excerpt
-          date(formatString: "D MMMM YYYY")
-          rawDate: date
-        }
-        headings {
-          headingValue: value
         }
         excerpt(pruneLength: 5000)
         objectID: id
@@ -28,10 +23,9 @@ const postQuery = `{
 }`
 
 const flatten = arr =>
-  arr.map(({ node: { fields, frontmatter, headings, ...rest } }) => ({
+  arr.map(({ node: { fields, frontmatter, ...rest } }) => ({
     ...fields,
     ...frontmatter,
-    ...headings,
     ...rest,
   }))
 


### PR DESCRIPTION
eliminate dead code, add [inlineCodeMarker](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-remark-prismjs/README.md#inline-code-blocks) to gatsby-remark-prismjs options in config and apply to inline code blocks in Credits.